### PR TITLE
Add live-server development server plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [notify](https://github.com/MikeKovarik/rollup-plugin-notify) – Display errors as system notifications.
 - [progress](https://github.com/jkuri/rollup-plugin-progress) - Show build progress in the console.
 - [serve](https://github.com/thgh/rollup-plugin-serve) - Development Server in a Plugin.
+- [liveServe](https://bitbucket.org/robhicks55/rollup-plugin-live-server) - [live-server](https://www.npmjs.com/package/live-server) hooked into rollup as a development server.
 - [sizes](https://github.com/tivac/rollup-plugin-sizes) - Display bundle content and size in the console.
 - [size-snapshot](https://github.com/TrySound/rollup-plugin-size-snapshot) - Track bundle size and treeshakability with ease.
 - [visualizer](https://github.com/btd/rollup-plugin-visualizer) - Bundle and dependency visualizer.
@@ -52,6 +53,7 @@ Plugins for working with CSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.
 - [scss](https://github.com/thgh/rollup-plugin-scss) - Compile SASS and CSS.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
+- [stylus-to-css](https://github.com/robhicks/rollup-plugin-stylus-to-css) - Compile Stylus to css and make it avaialbe to import.
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
 
 ### Frameworks

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Plugins for working with CSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.
 - [scss](https://github.com/thgh/rollup-plugin-scss) - Compile SASS and CSS.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
-- [stylus-to-css](https://github.com/robhicks/rollup-plugin-stylus-to-css) - Compile Stylus to css and make it avaialbe to import.
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
 
 ### Frameworks


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

- [x ] I have read, and re-read the [Contributing Guidelines](.github/COONTRIBUTING.md)
- [x ] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

This plugin will give developers webpack-developer-server like experience using the wildly-popular, well-tested [live-server](https://www.npmjs.com/package/live-server). This plugin is different than rollup-plugin-serve. That plugin creates a server from scratch and does't support live reloading.
