### PR TITLE
Add `lit-html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Plugins for working with template languages.
 - [eft](https://github.com/ClassicOldSong/rollup-plugin-eft) - Compile ef.js templates.
 - [ejs](https://github.com/trofima/rollup-plugin-ejs) - Compile .EJS templates.
 - [jst](https://github.com/btd/rollup-plugin-jst) - Compile Lodash templates.
+- [lit-html](https://gitlab.com/rockerest/rollup-plugin-lit-html) - Compile "plain" .html files as `lit-html` templates
 - [posthtml-template](https://github.com/Vanilla-IceCream/rollup-plugin-posthtml-template) - Seamless integration with PostHTML
 - [pug](https://github.com/aMarCruz/rollup-plugin-pug) - Compile Pug Templates as es6 modules.
 - [pug-html](https://github.com/tycho01/rollup-plugin-pug-html) - Import Pug Templates as HTML strings during a build.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### rollup-plugin-lit-html

This addition lists `lit-html` as one of the options in the templating section. I chose this section because I think it fits better than others, but arguments could be made that `lit-html` is not strictly a templating library, and this plugin modifies the code output so that the HTML is converted into a template function for use with other `lit-html` tooling (like `render`) or `lit-element`.

I'm happy to move the category this is in, but I think most people will perceive `lit-html` as being a templating tool.

As implied by the name, `rollup-plugin-lit-html` allows an application to separate their `lit-html` template (essentially just raw HTML with template string interpolation) from the rest of their JavaScript. It's not for everyone, as many people like mixing the two, but for those who like to separate their JS and their HTML, it's a non-trivial task to extract the HTML from the JS when you use `lit-html`.

I think this is very useful for those people, and there's nothing like it out there that I've found, and certainly nothing like it on this list.

