### PR TITLE
Add rollup-plugin-server-io to Output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Plugins which affect the final output of a bundle.
 - [preserve-shebang](https://github.com/developit/rollup-plugin-preserve-shebang) - Preserves leading shebang in a build entry.
 - [prettier](https://github.com/mjeanroy/rollup-plugin-prettier) - Run prettier on a bundle.
 - [rebase](https://github.com/sebastian-software/rollup-plugin-rebase) - Copies and adjusts asset references to new destination-relative location.
+- [server-io](https://gitlab.com/newbranltd/server-io-core) - All-in-one development server solution with reload, open and console debugger.
 - [shift-header](https://github.com/jacksonrayhamilton/rollup-plugin-shift-header) - Move comment headers to the top of a bundle.
 - [static-site](https://gitlab.com/thekelvinliu/rollup-plugin-static-site) - Generate HTML for a bundle.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.


### PR DESCRIPTION
Add rollup-plugin-server-io to output section

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x ] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [ x] I have searched to ensure the suggested item doesn't exist on this list
- [ x] This PR contains only one item

### Please Describe Your Addition

Add plugin-rollup-server-io and All-in-one development server solution, with reload, open, console debugger, files injection (to HTML), proxy, and allow injecting other middlewares. 