### PR TITLE
Add rollup-plugin-less-tilde-importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Plugins for working with CSS.
 - [embed-css](https://github.com/kei-ito/rollup-plugin-embed-css) - Import and append CSS to a bundle.
 - [less](https://github.com/xiaofuzi/rollup-plugin-less) - Compile LESS files.
 - [less-modules](https://github.com/katrotz/rollup-plugin-less-modules) - Import or Bundle LESS files.
+- [less-tilde-importer](https://github.com/ovh-ux/rollup-plugin-less-tilde-importer) - Provide ~ (tilde) prefix as a way to tell less compiler that it should resolve path using a configured array of module directories.
 - [modular-css](https://github.com/tivac/modular-css#rollup) - Alternative CSS Modules implementation supporting Rollup.
 - [postcss](https://github.com/egoist/rollup-plugin-postcss) - Seamless integration with PostCSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

`rollup-plugin-less-tilde-importer` provide ~ (tilde) prefix as a way to tell less compiler that it should resolve path using a configured array of module directories.

### Previous attempt

ref: #28