### PR TITLE
Added version-injector to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Plugins which affect the final output of a bundle.
 - [static-site](https://gitlab.com/thekelvinliu/rollup-plugin-static-site) - Generate HTML for a bundle.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.
 - [uglify](https://github.com/TrySound/rollup-plugin-uglify) - Minify a bundle with UglifyJS.
-
+- [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files. 
 ### Templating
 
 Plugins for working with template languages.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Plugins which affect the final output of a bundle.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.
 - [uglify](https://github.com/TrySound/rollup-plugin-uglify) - Minify a bundle with UglifyJS.
 - [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files. 
+
 ### Templating
 
 Plugins for working with template languages.


### PR DESCRIPTION
Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

This plugin will inject the application's version number and/or the build date into built js, html, and css files. This is extremely helpful for debugging especially if multiple versions of static files are uploaded to a web server/cdn. It also helps with logging as the current version and/or build date can be dynamically sent to log services.  

[Github repo](https://github.com/djhouseknecht/rollup-plugin-version-injector)
