### PR TITLE
Add rollup-plugin-zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Plugins which affect the final output of a bundle.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.
 - [uglify](https://github.com/TrySound/rollup-plugin-uglify) - Minify a bundle with UglifyJS.
 - [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files. 
+- [zip](https://github.com/mentaljam/rollup-plugin-zip) - Pack all assets into a zip file.
 
 ### Templating
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/mentaljam/rollup-plugin-zip

### Please Describe Your Addition

Plugin to zip up emitted files. It was inspired by the zip-webpack-plugin.

This plugin doesn't list the output directory but gets entries from the resulting bundle.