### PR TITLE
Add rollup-plugin-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [notify](https://github.com/MikeKovarik/rollup-plugin-notify) – Display errors as system notifications.
 - [progress](https://github.com/jkuri/rollup-plugin-progress) - Show build progress in the console.
 - [serve](https://github.com/thgh/rollup-plugin-serve) - Development Server in a Plugin.
+- [dev](https://github.com/pearofducks/rollup-plugin-dev) - Development server with additional logging and options.
 - [sizes](https://github.com/tivac/rollup-plugin-sizes) - Display bundle content and size in the console.
 - [size-snapshot](https://github.com/TrySound/rollup-plugin-size-snapshot) - Track bundle size and treeshakability with ease.
 - [visualizer](https://github.com/btd/rollup-plugin-visualizer) - Bundle and dependency visualizer.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/pearofducks/rollup-plugin-dev

### Please Describe Your Addition

This plugin is intended to act as an _alternative_ to (not compete with) [rollup-plugin-serve](https://github.com/thgh/rollup-plugin-serve).

To ensure users can find the right plugin for their needs, I've linked to _serve_ early on in the README, and suggested it for users who only need to serve static files.

This plugin, compared to _serve_ offers the following:
- based on Koa, so fully extensible by the user
- detailed logging of requests (see screenshot in repo's README)
- full proxy support
- support for a basepath in the URL
- will automatically turn itself off (with a notification) for production builds