### PR TITLE
add rollup-plugin-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ and external modules.
 - [import-alias](https://github.com/Hedzer/rollup-plugin-import-alias) - Maps an import path to another.
 - [includepaths](https://github.com/dot-build/rollup-plugin-includepaths) – Provide base paths from which to resolve imports.
 - [inject](https://github.com/rollup/rollup-plugin-inject) - Scans for global variables and injects `import` statements.
+- [internal](https://github.com/ashleyw/rollup-plugin-internal) - Explicitly declare dependencies as internal.
 - [legacy](https://github.com/rollup/rollup-plugin-legacy) - Add export statements to plain scripts.
 - [named-directory](https://github.com/frostney/rollup-plugin-named-directory) - Provides shortcuts for colocated modules in directories.
 - [node-builtins](https://github.com/calvinmetcalf/rollup-plugin-node-builtins) - Node builtin modules as ES modules.


### PR DESCRIPTION
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/ashleyw/rollup-plugin-internal

### Please Describe Your Addition

Allows for explicitly declaring dependencies as internal.

Works well with other plugins which mark dependencies as external. For example, [rollup-plugin-auto-external](https://www.npmjs.com/package/rollup-plugin-auto-external) will mark ALL dependencies as external — but you may want to selectively bundle a few.