### PR TITLE
Add rollup-plugin-output-manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Plugins which affect the final output of a bundle.
 - [iife](https://github.com/eight04/rollup-plugin-iife) - Convert ES modules to Immediately Invoked Function Expressions.
 - [license](https://github.com/mjeanroy/rollup-plugin-license) - Add Licensing to a bundle.
 - [live-reload](https://github.com/thgh/rollup-plugin-livereload) - Live reloading for a bundle.
+- [output-manifest](https://github.com/shuizhongyueming/rollup-plugin-output-manifest) - Generating a chunk manifest.
 - [preserve-shebang](https://github.com/developit/rollup-plugin-preserve-shebang) - Preserves leading shebang in a build entry.
 - [prettier](https://github.com/mjeanroy/rollup-plugin-prettier) - Run prettier on a bundle.
 - [rebase](https://github.com/sebastian-software/rollup-plugin-rebase) - Copies and adjusts asset references to new destination-relative location.


### PR DESCRIPTION

Awesome Contribution Checklist:

- [ x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x ] I have searched to ensure the suggested item doesn't exist on this list
- [x ] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/shuizhongyueming/rollup-plugin-output-manifest

### Please Describe Your Addition

This plugin can generate a manifest file for all chunk. So we can use this manifest to dynamically load chunk with dynamic content hash in the output file name.