### PR TITLE
Add rollup-plugin-emit-ejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Plugins which affect the final output of a bundle.
 - [copy-assets](https://github.com/bengsfort/rollup-plugin-copy-assets) - Copy specified assets to the output directory.
 - [cpy](https://github.com/shrynx/rollup-plugin-cpy) - Easily copy files and folders during a build.
 - [delete](https://github.com/vladshcherbin/rollup-plugin-delete) - Delete files and folders during a build.
+- [emit-ejs](https://github.com/juliendargelos/rollup-plugin-emit-ejs) - Emit files from ejs templates.
 - [espruino](https://github.com/joakim/rollup-plugin-espruino) - Send a bundle to [Espruino](http://www.espruino.com) devices.
 - [filesize](https://github.com/ritz078/rollup-plugin-filesize) - Display the file size of the bundle in the console.
 - [generate-html-template](https://github.com/bengsfort/rollup-plugin-generate-html-template) - Generate an HTML file for a bundle.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/juliendargelos/rollup-plugin-emit-ejs

### Please Describe Your Addition

This plugin allows for generating files from ejs templates. It includes a basic layout system and provides `javascripts` and `stylesheets` helper variables to link bundled files to html pages.