### PR TITLE
add rollup-plugin-block

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Plugins which affect code.
 
 Plugins which affect the Rollup workflow.
 
+- [block](https://github.com/tjenkinson/rollup-plugin-block) – Ensure certain files don't become part of the build.
 - [browsersync](https://github.com/4lejandrito/rollup-plugin-browsersync) – Serves a bundle via [Browsersync](https://browsersync.io/).
 - [browserify-transform](https://www.npmjs.com/package/rollup-plugin-browserify-transform) - Use Browserify transforms in a build.
 - [conditional](https://github.com/AgronKabashi/rollup-plugin-conditional) – Conditionally execute plugins.


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/tjenkinson/rollup-plugin-block

### Please Describe Your Addition
Sometimes you want to have separate builds for dev and production. You might use the [replace](https://github.com/rollup/rollup-plugin-replace) plugin to conditionally import certain files. This plugin lets you make sure that a file that is meant for one build isn't accidentally compiled into another.
