### PR TITLE
add: rollup-plugin-off-main-thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Plugins which affect the Rollup workflow.
 - [execute](https://github.com/audinue/rollup-plugin-execute) - Execute shell commands sequentially during a build.
 - [html-entry](https://github.com/leogr/rollup-plugin-html-entry) – Allows use HTML Script Tags as entry points.
 - [jscc](https://github.com/aMarCruz/rollup-plugin-jscc) – Conditional compilation and declaration of ES6 imports.
-- [loadz0r](https://github.com/surma/rollup-plugin-loadz0r) - Code-splitting across Workers and the UI Thread.
+- [off-main-thread](https://github.com/surma/rollup-plugin-off-main-thread) - Use ES6 modules with Web Workers.
 - [make](https://github.com/btmorex/rollup-plugin-make) - Build dependency files suitable for make
 - [multi-entry](https://github.com/rollup/rollup-plugin-multi-entry) - Multiple entry points for a bundle.
 - [run](https://github.com/rollup/rollup-plugin-run) - Run your bundle after it's generated.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/surma/rollup-plugin-off-main-thread

### Please Describe Your Addition

Use Rollup with workers and ES6 modules _today_. loadz0r has been replaced by off-main-thread.