### PR TITLE
add: rollup-plugin-consts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ and external modules.
 - [bower-resolve](https://github.com/mjeanroy/rollup-plugin-bower-resolve) – Use Bower the resolution algorithm.
 - [cjs-es](https://github.com/eight04/rollup-plugin-cjs-es) - Convert CommonJS modules without proxying and reassignment.
 - [commonjs](https://github.com/rollup/rollup-plugin-commonjs) - Convert CommonJS modules to ES Modules.
+- [consts](https://github.com/NotWoods/rollup-plugin-consts) - Import constants at build time.
 - [external-globals](https://github.com/eight04/rollup-plugin-external-globals) - Replace imported bindings with a global variable.
 - [force-binding](https://github.com/tehvgg/rollup-plugin-force-binding) - Composes multi-entry and node-resolve to prevent duplicated imports.
 - [glob-import](https://github.com/kei-ito/rollup-plugin-glob-import) - Glob support for import statements.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/NotWoods/rollup-plugin-consts

### Please Describe Your Addition

Allows for importing constants at built time. It serves a similar purpose to [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace), but lets constants be imported as modules instead of being string replacements.
