### PR TITLE
add: rollup-plugin-bundle-scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Plugins which help with code quality.
 
 Plugins for working with CSS.
 
+- [bundle-scss](https://github.com/weizhenye/rollup-plugin-bundle-scss) - Bundle all SCSS imports into one SCSS file.
 - [collect-sass](https://github.com/nathancahill/rollup-plugin-collect-sass) - Compiler SASS files in a single context.
 - [css-only](https://github.com/thgh/rollup-plugin-css-only) – Output plain CSS.
 - [css-porter](https://github.com/RJHwang/rollup-plugin-css-porter) - Combine CSS imports and output to file.
@@ -160,7 +161,7 @@ Plugins which affect the final output of a bundle.
 - [static-site](https://gitlab.com/thekelvinliu/rollup-plugin-static-site) - Generate HTML for a bundle.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.
 - [uglify](https://github.com/TrySound/rollup-plugin-uglify) - Minify a bundle with UglifyJS.
-- [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files. 
+- [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files.
 - [zip](https://github.com/mentaljam/rollup-plugin-zip) - Pack all assets into a zip file.
 
 ### Templating


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/weizhenye/rollup-plugin-bundle-scss

### Please Describe Your Addition

It bundles all SCSS imports into one SCSS file. It's useful when writing UI components with SCSS and providing one SCSS file to users for theming.