### PR TITLE
Add a link to rollup-plugin-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Plugins which affect the Rollup workflow.
 
 - [browsersync](https://github.com/4lejandrito/rollup-plugin-browsersync) – Serves a bundle via [Browsersync](https://browsersync.io/).
 - [browserify-transform](https://www.npmjs.com/package/rollup-plugin-browserify-transform) - Use Browserify transforms in a build.
+- [command](https://github.com/Vehmloewff/rollup-plugin-command) - Run commands and call functions when bundles are generated.
 - [conditional](https://github.com/AgronKabashi/rollup-plugin-conditional) – Conditionally execute plugins.
 - [execute](https://github.com/audinue/rollup-plugin-execute) - Execute shell commands sequentially during a build.
 - [html-entry](https://github.com/leogr/rollup-plugin-html-entry) – Allows use HTML Script Tags as entry points.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Conntributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/Vehmloewff/rollup-plugin-command

### Please Describe Your Addition

This PR aims at adding `rollup-plugin-command` to the awesome list.

This plugin is very similar to [`rollup-plugin-execute`](https://github.com/audinue/rollup-plugin-execute), but has a couple distinguishing features.

- This plugin allows both shell commands to be run _and_ functions to be called.  `rollup-plugin-execute` only supports shell commands.
- This plugin has, unlike `rollup-plugin-execute`, an `exitOnFail` option.  This is very important if you are using this plugin to run tests.
