### PR TITLE
Add rollup-plugin-git-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ and external modules.
 - [consts](https://github.com/NotWoods/rollup-plugin-consts) - Import constants at build time.
 - [external-globals](https://github.com/eight04/rollup-plugin-external-globals) - Replace imported bindings with a global variable.
 - [force-binding](https://github.com/tehvgg/rollup-plugin-force-binding) - Composes multi-entry and node-resolve to prevent duplicated imports.
+- [git-version](https://gitlab.com/IvanSanchez/rollup-plugin-git-version) - Inject git information when importing version from package.json.
 - [glob-import](https://github.com/kei-ito/rollup-plugin-glob-import) - Glob support for import statements.
 - [ignore](https://github.com/alexlur/rollup-plugin-ignore) - Ignore modules by replacing with empty objects.
 - [import-alias](https://github.com/Hedzer/rollup-plugin-import-alias) - Maps an import path to another.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://gitlab.com/IvanSanchez/rollup-plugin-git-version

### Please Describe Your Addition

Injects git branch and revision hash into `import { version } from "package.json"`. e.g. if your `package.json` contains version: `"1.2.3"`, this plugin turns the imported value into `"1.2.3+master.890abc"`.

If I recall correctly, `rollup-plugin-git-version` was present in the previous incarnations of the rollup plugins list.