### PR TITLE
Add rollup-plugin-styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Plugins for working with CSS.
 - [postcss](https://github.com/egoist/rollup-plugin-postcss) - Seamless integration with PostCSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.
 - [scss](https://github.com/thgh/rollup-plugin-scss) - Compile SASS and CSS.
-- [styles](https://github.com/Anidetrix/rollup-plugin-styles) - Universal Rollup plugin for styles: PostCSS, Sass, Less, Stylus and more.
+- [styles](https://github.com/Anidetrix/rollup-plugin-styles) - Universal plugin for styles: PostCSS, Sass, Less, Stylus and more.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Plugins for working with CSS.
 - [postcss](https://github.com/egoist/rollup-plugin-postcss) - Seamless integration with PostCSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.
 - [scss](https://github.com/thgh/rollup-plugin-scss) - Compile SASS and CSS.
+- [styles](https://github.com/Anidetrix/rollup-plugin-styles) - Universal Rollup plugin for styles: PostCSS, Sass, Less, Stylus and more.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/Anidetrix/rollup-plugin-styles

### Please Describe Your Addition

Universal plugin for styles: PostCSS, Sass, Less, Stylus and more.

Differs from rollup-plugin-postcss:
* Written completely in TypeScript
* Up-to-date CSS Modules implementation
* Built-in @import handler
* Built-in assets handler
* Code splitting support
* Ability to emit pure CSS for other plugins
* Correct multiple instance support with check for already processed files
* Support for implementation and fibers forcing for Sass
* Support for partials and ~ in Less import statements
* Sourcemaps include source content
* Proper sourcemap generation for all loaders
* Correct inline sourcemaps
* Correct relative source paths in extracted sourcemaps
* Extracts sourcemaps from loaded files
* More smaller things that I forgot