### PR TITLE
feat(plugin): add legacy-bundle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Plugins which affect the final output of a bundle.
 - [gzip](https://github.com/kryops/rollup-plugin-gzip) - Create a compressed GZ artifact for your bundle.
 - [hash](https://github.com/phamann/rollup-plugin-hash) – Generate output files with unique hashes.
 - [iife](https://github.com/eight04/rollup-plugin-iife) - Convert ES modules to Immediately Invoked Function Expressions.
+- [legacy-bundle](https://github.com/stalniy/rollup-plugin-legacy-bundle) - Generate bundle for browsers that do not support ES modules
 - [license](https://github.com/mjeanroy/rollup-plugin-license) - Add Licensing to a bundle.
 - [live-reload](https://github.com/thgh/rollup-plugin-livereload) - Live reloading for a bundle.
 - [manifest-json](https://github.com/adamzerella/rollup-plugin-manifest-json) - Generate a `manifest.json` file for a PWA.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/stalniy/rollup-plugin-legacy-bundle

### Please Describe Your Addition

This plugin allows to generate legacy bundle for older browsers seamlessly (those that don't support ES modules). It also provides integration with `@rollup/plugin-html`, so it can be quickly added to the existing project. Useful for rollup generated apps (e.g., static website generators) to cover bigger audience. 

This plugins resolves the original request in issue rollup/plugins#119

**P.S.:** I haven't written tests yet but this plugin is used to generate documentation in one of my personal Open Source projects.
