### PR TITLE
Fix link to Babel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Plugins created and maintained by the Rollup organization.
 
 - [alias](https://github.com/rollup/plugins/tree/master/packages/alias) - Alias modules in a build.
-- [babel](https://github.com/rollup/rollup-plugin-babel) - Seamless integration with Babel.
+- [babel](https://github.com/rollup/plugins/tree/master/packages/babel) - Seamless integration with Babel.
 - [buble](https://github.com/rollup/plugins/tree/master/packages/buble) – Transpile with Bublé.
 - [commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs) - Convert CommonJS modules to ES Modules.
 - [dsv](https://github.com/rollup/plugins/tree/master/packages/dsv) - Convert CSV and TSV files into JavaScript modules.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

Hi!
It seems the link to the Babel plugin should refer to the actual location of the package.

