### PR TITLE
add: external-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ and external modules.
 
 Plugins which allow importing other types of files as modules.
 
+- [external-assets](https://github.com/soufyakoub/rollup-plugin-external-assets) - Make assets external but include them in the output.
 - [file-as-blob](https://gitlab.com/IvanSanchez/rollup-plugin-file-as-blob) – Import a file as a `blob:` URL.
 - [glsl](https://github.com/vwochnik/rollup-plugin-glsl) - Import GLSL shaders as compressed strings.
 - [glslify](https://github.com/glslify/rollup-plugin-glslify) - Import GLSL strings with [glslify](https://github.com/glslify/glslify).


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/soufyakoub/rollup-plugin-external-assets

### Please Describe Your Addition

Imports to assets whose resolved id matches the provided pattern(s) are made external, but the assets themselves are emitted in the final output, and the imports are correctly updated to reference the target location of those assets.

This is useful for package creators. For example, a reusable react component that imports assets and the author wants to let the user choose how to bundle them.

`smart-asset` does the same thing with the "copy" mode, but from my experiments, since the provided assets target directory has to be relative to the output file, it only works as expected when the output is a single chunk.

`external-assets` however, since most of the work is actually done by rollup:
- Supports multiple output chunks.
- Supports filename patterns, like `chunkFileNames`, `assetFileNames` and `entryFileNames`.
- Changes to assets trigger rebuilds in watch mode. (this is achieved by loading a proxy module for the asset id, but I'm not sure if it works as expected for all cases, help would be appreciated)
- Assets with the same source are deduplicated.
- Produces source maps.
- Multiple instances of the plugin can be used at the same time. (don't know why would this be needed but it is what it is :laughing: )
