### PR TITLE
Adds build statistics plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Plugins created and maintained by the Rollup organization.
 
 ### All-Purpose Awesome
 
+- [build-statistics](https://github.com/nemwiz/build-statistics-plugin) - Plugin that keeps a continuous log of your build time.
+- [dev](https://github.com/pearofducks/rollup-plugin-dev) - Development server with additional logging and options.
 - [graph](https://github.com/ondras/rollup-plugin-graph) – Generates a module dependency graph.
 - [nollup](https://github.com/PepsRyuu/nollup) - Rollup-compatible development bundler providing Hot Module Replacement.
 - [notify](https://github.com/MikeKovarik/rollup-plugin-notify) – Display errors as system notifications.
 - [progress](https://github.com/jkuri/rollup-plugin-progress) - Show build progress in the console.
 - [rollpkg](https://github.com/rafgraph/rollpkg) - No config build tool to create packages with Rollup and TypeScript
 - [serve](https://github.com/thgh/rollup-plugin-serve) - Development Server in a Plugin.
-- [dev](https://github.com/pearofducks/rollup-plugin-dev) - Development server with additional logging and options.
 - [sizes](https://github.com/tivac/rollup-plugin-sizes) - Display bundle content and size in the console.
 - [size-snapshot](https://github.com/TrySound/rollup-plugin-size-snapshot) - Track bundle size and treeshakability with ease.
 - [visualizer](https://github.com/btd/rollup-plugin-visualizer) - Bundle and dependency visualizer.


### PR DESCRIPTION
Adds build statistics plugin, moves dev plugin so that the list is alphabetically sorted

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/nemwiz/build-statistics-plugin

### Please Describe Your Addition

A plugin that keeps a continuous log of build time and helps to monitor team productivity.
I wrote a blog post on my motivation to build this plugin.
https://www.ninkovic.dev/blog/2021/how-to-acquire-more-time-for-technical-tasks


