### PR TITLE
add external-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Plugins created and maintained by the Rollup organization.
 - [buble](https://github.com/rollup/plugins/tree/master/packages/buble) – Transpile with Bublé.
 - [commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs) - Convert CommonJS modules to ES Modules.
 - [dsv](https://github.com/rollup/plugins/tree/master/packages/dsv) - Convert CSV and TSV files into JavaScript modules.
+- [external-assets](https://github.com/soufyakoub/rollup-plugin-external-assets) - Make assets external but include them in the output.
 - [html](https://github.com/rollup/plugins/tree/master/packages/html) - Creates HTML files to serve Rollup bundles
 - [image](https://github.com/rollup/plugins/tree/master/packages/image) - Import JPG, PNG, GIF and SVG images.
 - [inject](https://github.com/rollup/plugins/tree/master/packages/inject) - Scans for global variables and injects `import` statements.


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/soufyakoub/rollup-plugin-external-assets

### Please Describe Your Addition

Imports to assets whose resolved id matches the provided pattern(s) are made external, but the assets themselves are emitted in the final output, and the imports are correctly updated to reference the target location of those assets.

This is useful for package creators. For example, a reusable react component that imports assets and the author wants to let the user choose how to bundle them.

`smart-asset` does the same thing with the "copy" mode, but from my experiments, since the provided assets target directory has to be relative to the output file, it only works as expected when the output is a single chunk.

`rebase` does the same thing too, but I checked its source, and it seems that it's using `smart-asset` under the hood.

`external-assets` however, since most of the work is actually done by rollup:
- Supports multiple output chunks.
- Supports filename patterns, like `chunkFileNames`, `assetFileNames` and `entryFileNames`.
- Changes to assets trigger rebuilds in watch mode.
- Assets with the same source are deduplicated.
- Produces source maps.
