### PR TITLE
Add rollup-plugin-glsl-optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Plugins which allow importing other types of files as modules.
 
 - [file-as-blob](https://gitlab.com/IvanSanchez/rollup-plugin-file-as-blob) – Import a file as a `blob:` URL.
 - [glsl](https://github.com/vwochnik/rollup-plugin-glsl) - Import GLSL shaders as compressed strings.
+- [glsl-optimize](https://github.com/docd27/rollup-plugin-glsl-optimize) - Import and optimize GLSL shaders as compressed strings. Supports [glslify](https://github.com/glslify/glslify).
 - [glslify](https://github.com/glslify/rollup-plugin-glslify) - Import GLSL strings with [glslify](https://github.com/glslify/glslify).
 - [gltf](https://github.com/bengsfort/rollup-plugin-gltf) - Import glTF 3d models as a URI or inlined JSON.
 - [html](https://github.com/bdadam/rollup-plugin-html) - Import html files as strings.


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/docd27/rollup-plugin-glsl-optimize

### Please Describe Your Addition

Import and optimize GLSL shaders as compressed strings. Supports [glslify](https://github.com/glslify/glslify).

###  Comparison to existing [rollup-plugin-glsl](https://github.com/vwochnik/rollup-plugin-glsl) & [rollup-plugin-glslify](https://github.com/glslify/rollup-plugin-glslify):
In addition to simply importing GLSL shaders as strings as these existing plugins do, this also provides:
- Semantic validation and macro preprocessing at bundle time (using [glslangValidator](https://github.com/KhronosGroup/glslang))
- Optimization (using [spirv-opt](https://github.com/KhronosGroup/SPIRV-Tools))