### PR TITLE
Add rollup-plugin-flat-dts

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Plugins which affect code.
 - [coffee-script](https://github.com/lautis/rollup-plugin-coffee-script) – Compile CoffeeScript.
 - [dts](https://github.com/Swatinem/rollup-plugin-dts) - Rollup `.d.ts` TypeScript Definition files.
 - [elm](https://github.com/ulisses-alves/rollup-plugin-elm) - Compile Elm.
+- [flat-dts](https://github.com/run-z/rollup-plugin-flat-dts) - `.d.ts` files flattener.
 - [jspicl](https://github.com/AgronKabashi/rollup-plugin-jspicl) - Transpile JavaScript into PICO-8 Lua.
 - [nodent](https://github.com/oligot/rollup-plugin-nodent) - Transpile ES2017 `async`/`await`.
 - [pegjs](https://github.com/cameronhunter/rollup-plugin-pegjs) - Import PEG.js grammars as parsers.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

<!-- url -->
https://github.com/run-z/rollup-plugin-flat-dts

### Please Describe Your Addition

TypeScript definition files (`.d.ts`) flattener.

Differences from `rollup-plugin-dts` and `rollup-plugin-ts`:

1. Most notably, this plugin relies on TypeScript's ability to emit single-file type definitions.
   Then it just updates the emitted type definition by replacing module names and removing unwanted exports.

   - This prevents unexpected module names otherwise emitted by `tsc`.
   - This is a more robust approach than an attempt to reproduce  TypeScript compiler's logic.

2. This plugin is able to emit [declaration maps](https://www.typescriptlang.org/tsconfig#declarationMap).

3. This plugin is able to split single `.d.ts` file onto multiple ones, e.g. corresponding to each package [entry point](https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_package_entry_points).

4. This plugin does not emit additional chunks that confuse IDEs and just isn't right to exist, as they don't correspond to any existing entry point of the package.

Due to its straightforward approach, the plugin applies several limitations on the code base, These limitations are cleanly stated and are not exotic. It isn't hard to adhere to them. In fact, a lot of projects already do. The only caveat is to declare which exported symbols to remove from emitted type definition (e.g. by marking them `@internal` or with a glob pattern).

I had to develop this plugin as none of the existing solutions were able to emit a correct type definition. Now this plugin is used on a few dozens of my own projects. So I hope it could be useful for the others too.