### PR TITLE
Add node-polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Plugins which affect the Rollup workflow.
 - [html-entry](https://github.com/leogr/rollup-plugin-html-entry) – Allows use HTML Script Tags as entry points.
 - [incremental](https://github.com/mprt-org/rollup-plugin-incremental) - Recompile only changed modules in watch mode.
 - [jscc](https://github.com/aMarCruz/rollup-plugin-jscc) – Conditional compilation and declaration of ES6 imports.
+- [node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills) - Allows node builtins to be imported.
 - [off-main-thread](https://github.com/surma/rollup-plugin-off-main-thread) - Use ES6 modules with Web Workers.
 - [make](https://github.com/btmorex/rollup-plugin-make) - Build dependency files suitable for make
 - [sourcemaps](https://github.com/maxdavidson/rollup-plugin-sourcemaps) – Load external source maps from URIs.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [X] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [X] I have searched to ensure the suggested item doesn't exist on this list
- [X] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/ionic-team/rollup-plugin-node-polyfills

### Please Describe Your Addition

This is a mature package that polyfills Node builtins (such as EventEmitter). It is actually recommended by a Rollup warning that reads as follows:

```
Creating a browser bundle that depends on Node.js built-in modules ("events"). You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills
```

So, I was surpised that it's not on this list! As I've been using this list as a reference so frequently, I figured I'd open this PR to add this entry.

Thanks for maintaining!