### PR TITLE
add: prompt-replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Plugins for working with template languages.
 Plugins which search for, and replace text in a bundle.
 
 - [ascii](https://github.com/mbostock/rollup-plugin-ascii) – Rewrite non-ASCII characters as string literals.
+- [prompt-replace](https://github.com/MacFJA/rollup-plugin-prompt-replace) – Ask at runtime the replacement value.
 - [re](https://github.com/jetiny/rollup-plugin-re) – Replace text with Regular Expressions.
 - [strip-code](https://github.com/se-panfilov/rollup-plugin-strip-code) - Remove text with Regular Expressions.
 


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/MacFJA/rollup-plugin-prompt-replace

### Please Describe Your Addition

This plugin is a wrapper around the [replace](https://github.com/rollup/plugins/tree/master/packages/replace) plugin.
It add the following feature: when Rollup is running it will ask the user to input the value to replace.

This can be useful if you need to provide token, credential, etc. at build time
(and in my case it was during build time for functional testing)