### PR TITLE
Add rollup-plugin-svg-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Plugins which allow importing other types of files as modules.
 - [rust](https://github.com/DrSensor/rollup-plugin-rust) - Compile Rust as WebAssembly or a Node.js Add-on.
 - [spritesmith](https://github.com/linjinying/rollup-plugin-sprite) — Convert a set of images into a spritesmith sprite-sheet.
 - [string](https://github.com/TrySound/rollup-plugin-string) – Import text files as strings.
+- [svg-import](https://github.com/korywka/rollup-plugin-svg-import) - Import SVG files as SVG DOM Node or string.
 - [svg-sprite](https://github.com/VladShcherbin/rollup-plugin-svg-sprite) — Import SVG files as an external SVG sprite.
 - [svg-to-symbol](https://github.com/fjc0k/rollup-plugin-svg-to-symbol) - Import SVG files as symbol strings.
 - [svgo](https://github.com/porsager/rollup-plugin-svgo) - Import SVG files as strings


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/korywka/rollup-plugin-svg-import

### Please Describe Your Addition

This plugin imports SVG images as `<svg>` DOM node, not `<img>` like the official one. Optionally it can import SVG files as string (not the main purpose of this plugin). This plugin is live for ~2 years and have ~3800 weekly downloads.
