### PR TITLE
add external-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ and external modules.
 - [bower-resolve](https://github.com/mjeanroy/rollup-plugin-bower-resolve) – Use Bower the resolution algorithm.
 - [cjs-es](https://github.com/eight04/rollup-plugin-cjs-es) - Convert CommonJS modules without proxying and reassignment.
 - [consts](https://github.com/NotWoods/rollup-plugin-consts) - Import constants at build time.
+- [external-assets](https://github.com/recursive-beast/rollup-plugin-external-assets) - Make assets external but include them in the output.
 - [external-globals](https://github.com/eight04/rollup-plugin-external-globals) - Replace imported bindings with a global variable.
 - [force-binding](https://github.com/tehvgg/rollup-plugin-force-binding) - Composes multi-entry and node-resolve to prevent duplicated imports.
 - [glob-import](https://github.com/kei-ito/rollup-plugin-glob-import) - Glob support for import statements.


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/soufyakoub/rollup-plugin-external-assets

### Please Describe Your Addition

Imports to assets whose resolved id matches the provided pattern(s) are made external, but the assets themselves are emitted in the final output, and the imports are correctly updated to reference the target location of those assets.

This is useful for package creators. For example, a reusable react component that imports assets and the author wants to let the user choose how to bundle them.

`smart-asset` does the same thing with the "copy" mode, but from my experiments, since the provided assets target directory has to be relative to the output file, it only works as expected when the output is a single chunk.

`rebase` does the same thing too, but I checked its source, and it seems that it's using `smart-asset` under the hood.

`external-assets` however, since most of the work is actually done by rollup:
- Supports multiple output chunks.
- Supports filename patterns, like `chunkFileNames`, `assetFileNames` and `entryFileNames`.
- Changes to assets trigger rebuilds in watch mode.
- Assets with the same source are deduplicated.
- Produces source maps.
