### PR TITLE
Add import-assertions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ and external modules.
 - [hoist-import-deps](https://github.com/vikerman/rollup-plugin-hoist-import-deps) - Avoid waterfalls when dynamically importing modules by hoisting import dependencies.
 - [ignore](https://github.com/alexlur/rollup-plugin-ignore) - Ignore modules by replacing with empty objects.
 - [import-alias](https://github.com/Hedzer/rollup-plugin-import-alias) - Maps an import path to another.
+- [import-assertions](https://github.com/swiing/rollup-plugin-import-assertions) - Add support for TC39 import assertions (e.g. assert types `css` and `json`)
 - [includepaths](https://github.com/dot-build/rollup-plugin-includepaths) – Provide base paths from which to resolve imports.
 - [named-directory](https://github.com/frostney/rollup-plugin-named-directory) - Provides shortcuts for colocated modules in directories.
 - [node-builtins](https://github.com/calvinmetcalf/rollup-plugin-node-builtins) - Node builtin modules as ES modules.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
  
  !!!! ATTENTION !!!!
  
  Due to a large number of submissions from folks who have not read or ignored the
  Contributing Guidelines, any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!
-->

Awesome Contribution Checklist:

<!-- DO NOT CHECK THE NEXT BOX IF YOU HAVE NOT READ THE GUIDELINES -->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/swiing/rollup-plugin-import-assertions

### Please Describe Your Addition

This plugin adds support for [TC39 import assertions](https://github.com/tc39/proposal-import-assertions). This is currently a stage 3 proposal.

Import assertions allow importing assets with the following syntax;

```js
import json from "./foo.json" assert { type: "json" };
import style from "./style.css" assert { type: "css" };
```

The latter is especially useful with custom elements.