### PR TITLE
Add rollup-license-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Plugins which affect the final output of a bundle.
 - [preserve-shebang](https://github.com/developit/rollup-plugin-preserve-shebang) - Preserves leading shebang in a build entry.
 - [prettier](https://github.com/mjeanroy/rollup-plugin-prettier) - Run prettier on a bundle.
 - [rebase](https://github.com/sebastian-software/rollup-plugin-rebase) - Copies and adjusts asset references to new destination-relative location.
+- [rollup-license-plugin](https://github.com/codepunkt/rollup-license-plugin) - Add a license compliance bill of materials to the output.
 - [shift-header](https://github.com/jacksonrayhamilton/rollup-plugin-shift-header) - Move comment headers to the top of a bundle.
 - [sri](https://github.com/JonasKruckenberg/rollup-plugin-sri) - Add subresource integrity attributes for your bundle.
 - [static-site](https://gitlab.com/thekelvinliu/rollup-plugin-static-site) - Generate HTML for a bundle.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [X] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [X] I have searched to ensure the suggested item doesn't exist on this list
- [X] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

[https://github.com/codepunkt/rollup-license-plugin](https://github.com/codepunkt/rollup-license-plugin)

### Please Describe Your Addition

I'm the maintainer of [`webpack-license-plugin`](https://github.com/codepunkt/webpack-license-plugin). It is used to build one or more bill of material files containing a list of all of the dependencies used in the build output for license compliance purposes - including their version, SPDX license identifier, license text and further information.

At my employer we've switched the bundling from webpack to rollup/vite for several of our products, so I've implemented `rollup-license-plugin` to offer the same API for rollup builds. I have read the Contribution Guidelines and understand that I might be violating the first rule. However, as it's the same API as `webpack-license-plugin` and I've been maintaining that for years, I think it should be fine.