### PR TITLE
Add rollup-plugin-gltf

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Plugins which allow importing other types of files as modules.
 - [glsl](https://github.com/vwochnik/rollup-plugin-glsl) - Import GLSL shaders as compressed strings.
 - [glsl-optimize](https://github.com/docd27/rollup-plugin-glsl-optimize) - Import and optimize GLSL shaders as compressed strings. Supports [glslify](https://github.com/glslify/glslify).
 - [glslify](https://github.com/glslify/rollup-plugin-glslify) - Import GLSL strings with [glslify](https://github.com/glslify/glslify).
-- [gltf](https://github.com/bengsfort/rollup-plugin-gltf) - Import glTF 3d models as a URI or inlined JSON.
+- [gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Import, transform, optimize, and compress glTF 3D models.
+- [gltf-inline](https://github.com/bengsfort/rollup-plugin-gltf) - Import glTF 3D models as a URI or inlined JSON.
 - [html](https://github.com/bdadam/rollup-plugin-html) - Import html files as strings.
 - [hypothetical](https://github.com/Permutatrix/rollup-plugin-hypothetical) - Import modules from a virtual filesystem.
 - [imagemin](https://github.com/malchata/rollup-plugin-imagemin) - Optimize images with [imagemin](https://github.com/imagemin/imagemin).

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Plugins which allow importing other types of files as modules.
 - [glsl-optimize](https://github.com/docd27/rollup-plugin-glsl-optimize) - Import and optimize GLSL shaders as compressed strings. Supports [glslify](https://github.com/glslify/glslify).
 - [glslify](https://github.com/glslify/rollup-plugin-glslify) - Import GLSL strings with [glslify](https://github.com/glslify/glslify).
 - [gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Import, transform, optimize, and compress glTF 3D models.
-- [gltf-inline](https://github.com/bengsfort/rollup-plugin-gltf) - Import glTF 3D models as a URI or inlined JSON.
 - [html](https://github.com/bdadam/rollup-plugin-html) - Import html files as strings.
 - [hypothetical](https://github.com/Permutatrix/rollup-plugin-hypothetical) - Import modules from a virtual filesystem.
 - [imagemin](https://github.com/malchata/rollup-plugin-imagemin) - Optimize images with [imagemin](https://github.com/imagemin/imagemin).


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/nytimes/rd-bundler-3d-plugins

### Please Describe Your Addition

With NYTimes R&D, I created the `rollup-plugin-gltf` plugin to import, transform, optimize, and compress 3D models in the glTF 2.0 (.gltf, .glb) file format. An existing plugin with this name on the list, created by @bengsfort, was focused on inlining glTF files in bundles as Base64 or JSON. Ben was kind enough to transfer the npm package name. The older package by Ben is no longer on npm, though I'm assuming it may be republished as `rollup-plugin-gltf-inline` (or similar) in the future, and have left it listed under a clarified name.