### PR TITLE
Added import manager to modules section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ and external modules.
 - [ignore](https://github.com/alexlur/rollup-plugin-ignore) - Ignore modules by replacing with empty objects.
 - [import-alias](https://github.com/Hedzer/rollup-plugin-import-alias) - Maps an import path to another.
 - [import-assertions](https://github.com/swiing/rollup-plugin-import-assertions) - Add support for TC39 import assertions (e.g. assert types `css` and `json`)
+- [import-manager](https://github.com/UmamiAppearance/rollup-plugin-import-manager) - Add, modify, and remove imports (cjs/es6/dynamic).
 - [includepaths](https://github.com/dot-build/rollup-plugin-includepaths) – Provide base paths from which to resolve imports.
 - [named-directory](https://github.com/frostney/rollup-plugin-named-directory) - Provides shortcuts for colocated modules in directories.
 - [node-builtins](https://github.com/calvinmetcalf/rollup-plugin-node-builtins) - Node builtin modules as ES modules.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

[rollup-plugin-import-manager](https://github.com/UmamiAppearance/rollup-plugin-import-manager)

### Please Describe Your Addition

**import-manager** is a plugin I have create, since many times I have changed imports for different builds. The plugin is a great way to easily achieve this. I use it by myself for many of my projects. The existing module plugins did not quite fit the needs I had. It is possible to remove imports, add new ones, move existing ones or modify them. 
