### PR TITLE
Add `rollup-plugin-unbundle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ and external modules.
 - [node-resolve-angular](https://github.com/OasisDigital/rollup-plugin-node-resolve-angular) - Node module resolution support for Angular 4+.
 - [ts-paths](https://github.com/bitshiftza/rollup-plugin-ts-paths) – Resolve modules from `tsconfig` paths.
 - [skypack-resolver](https://github.com/vinicius73/rollup-plugin-pika-resolver) - Use [Skypack CDN](https://skypack.dev/) for external dependencies.
+- [unbundle](https://github.com/run-z/rollup-plugin-unbundle) - Unbundle some dependencies.
 - [web-worker-loader](https://github.com/darionco/rollup-plugin-web-worker-loader) - Package Workers for NodeJS and the browser.
 
 ### Other File Imports


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/run-z/rollup-plugin-unbundle

### Please Describe Your Addition

Advanced semi-automatic `external` option customization.

Resolves module IDs back to their package names.

Respects custom `external` option. Makes it easier to implement by supplying package names rather JavaScript file paths.

Contains some bundling/externalizing heuristics suitable for package authors:

- Externalizes Node.js built-ins.
- Externalizes package `dependencies`.
  As they will be installed along the bundled package anyway.
- Externalizes package `peerDependencies`.
  As they _expected to be added_ to the package that depends on bundled one.
