### PR TITLE
Add tailwindcss-lit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plugins created and maintained by the Rollup organization.
 - [replace](https://github.com/rollup/plugins/tree/master/packages/replace) – Replace occurrences of a set of strings.
 - [run](https://github.com/rollup/plugins/tree/master/packages/run) - Run your bundle after it's generated.
 - [strip](https://github.com/rollup/plugins/tree/master/packages/strip) - Remove expressions from code.
-- [sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) - Compile 
+- [sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) - Compile
 , Flow, JSX.
 - [typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) - Seamless integration with Typescript.
 - [url](https://github.com/rollup/plugins/tree/master/packages/url) - Inline import files as data-URIs.
@@ -86,6 +86,7 @@ Plugins for working with CSS.
 - [styles](https://github.com/Anidetrix/rollup-plugin-styles) - Universal plugin for styles: PostCSS, Sass, Less, Stylus and more.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
+- [tailwindcss-lit](https://github.com/ouweiya/rollup-plugin-tailwindcss-lit) - Using Tailwind CSS in Lit.
 
 ### Frameworks
 


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/ouweiya/rollup-plugin-tailwindcss-lit

### Please Describe Your Addition

Using Tailwind CSS in [Lit](https://lit.dev/), importing CSS as modules, and supporting inline CSS compilation.

**Compile CSS modules**

```ts
import styles from 'index.css';

@customElement('my-element')
class One extends LitElement {
    static styles = [styles];

    render() {
        return html`<p class="text-blue-500">Hello</p>`;
    }
}
```

**Compile inline CSS**

```ts
static styles = [
    styles,
    css`
        :host {
            @apply text-blue-600;
            width: 100px;
        }
    `,
];
```

After compilation

```ts
static styles = [
    styles,
    css`
        :host {
            width: 100px;
        }
        :host {
            --tw-text-opacity: 1;
            color: rgb(37 99 235 / var(--tw-text-opacity));
        }
    `,
];
```