### PR TITLE
Add @nightlycommit/rollup-plugin-twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Plugins which affect the final output of a bundle.
 Plugins for working with template languages.
 
 - [twig](https://github.com/fm-ph/rollup-plugin-twig) - Import pre-compiled Twig.js templates.
+- [twig, by Twing](https://www.npmjs.com/package/@nightlycommit/rollup-plugin-twig) - Seamless integration between Rollup and Twig, fueled by [Twing](https://www.npmjs.com/package/twing).
 - [dustjs](https://github.com/chrisdothtml/rollup-plugin-dustjs) - Import Dust.js templates.
 - [eft](https://github.com/ClassicOldSong/rollup-plugin-eft) - Compile ef.js templates.
 - [ejs](https://github.com/trofima/rollup-plugin-ejs) - Compile .EJS templates.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [X] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [X] I have searched to ensure the suggested item doesn't exist on this list
- [X] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://gitlab.com/nightlycommit/rollup-plugin-twig

### Please Describe Your Addition

A `twig` plugin fueled by Twing. Twing is arguably a better Twig compiler than twig.js - which is the compiler that fuels the other twig plugin. However, I think that both can live together in the Rollup ecosystem.

From a pure quality point of view, this plugin is 100% covered - like Twing - and as such is likely to be less prone to regressions than the other one.