### PR TITLE
Add @vitrail/rollup-plugin-typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Plugins which affect code.
 - [purs](https://github.com/Pauan/rollup-plugin-purs) - Compile PureScript.
 - [regenerator](https://github.com/noTruth/rollup-plugin-regenerator) - Replace `async` functions with ES5 Promise functions.
 - [ts](https://github.com/wessberg/rollup-plugin-ts) - Transpile with Babel, TypeScript, or both, while respecting Browserslist and TypeScript declarations.
+- [@vitrail/rollup-plugin-typescript](https://www.npmjs.com/package/@vitrail/rollup-plugin-typescript) - Non-invasive, non-opinionated integration between Rollup and TypeScript.
 - [typescript2](https://github.com/ezolenko/rollup-plugin-typescript2) - Compile TypeScript v2.0+.
 
 ### Workflow


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

[https://gitlab.com/vitrail/rollup-plugin-typescript](https://gitlab.com/vitrail/rollup-plugin-typescript)

### Please Describe Your Addition

This plugin provides integration between Rollup and TypeScript with the following benefits:

* The plugin does not watch files by itself allowing it to be integrated into any build tool chain - it does not rely on a TypeScript watch program but uses an incremental watch program instead
* The plugin only compiles files that are part of the dependency graph of the entry points - it does not do any magic there since this is how the TypeScript compiler works
* The plugin is non-opinionated: compiler options are not enforces except source map support (which is mandatory to Rollup) and consider that developers know what they are doing and _why_.
* The plugin is substantially faster than both the other main alternatives
* The plugin project comes with a 100% code coverage and an API documentation