### PR TITLE
Add keep-css-imports plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plugins created and maintained by the Rollup organization.
 - [replace](https://github.com/rollup/plugins/tree/master/packages/replace) – Replace occurrences of a set of strings.
 - [run](https://github.com/rollup/plugins/tree/master/packages/run) - Run your bundle after it's generated.
 - [strip](https://github.com/rollup/plugins/tree/master/packages/strip) - Remove expressions from code.
-- [sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) - Compile 
+- [sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) - Compile
 , Flow, JSX.
 - [typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) - Seamless integration with Typescript.
 - [url](https://github.com/rollup/plugins/tree/master/packages/url) - Inline import files as data-URIs.
@@ -77,6 +77,7 @@ Plugins for working with CSS.
 - [css-only](https://github.com/thgh/rollup-plugin-css-only) – Output plain CSS.
 - [css-porter](https://github.com/RJHwang/rollup-plugin-css-porter) - Combine CSS imports and output to file.
 - [embed-css](https://github.com/kei-ito/rollup-plugin-embed-css) - Import and append CSS to a bundle.
+- [keep-css-imports](https://github.com/SLTKA/rollup-plugin-keep-css-imports) - Output separate CSS files and keep imports in JS, enabling the bundling of component libraries which allow consumers to "tree shake" unused components' CSS.
 - [less](https://github.com/xiaofuzi/rollup-plugin-less) - Compile LESS files.
 - [less-modules](https://github.com/katrotz/rollup-plugin-less-modules) - Import or Bundle LESS files.
 - [modular-css](https://github.com/tivac/modular-css#rollup) - Alternative CSS Modules implementation supporting Rollup.


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item (and follows the guide to remove trailing spaces  on `sucrase` description, I can remove line break instead)

### Please Provide a Link A Repository for Your Addition

[https://github.com/SLTKA/rollup-plugin-keep-css-imports](https://github.com/SLTKA/rollup-plugin-keep-css-imports)

### Please Describe Your Addition

`keep-css-imports` allows to maintain the original structure of style imports (CSS, SCSS, or SASS) without altering them during the bundling process. It will be helpful for building a components library and want to keep all CSS module imports untouched so consumer decide how to bundle or tree shake them.

If it meets SASS or SCSS import it will compile it and output as a single imported CSS file in `dist`. Plugin can be configured to maintain component folder structure or produce flattened output.

Rollup and Webpack based consumers can easily ignore the produced CSS file if component imported them was not used.

This is an alternative to CSS-in-JS plugins and allow consumers to produce separate Server Side Rendered HTML and CSS which loads much faster than dynamic (forces to wait for JS to run to inject CSS) or inline (doesn't allow separate CSS files caching in browsers) CSS-in-JS