### PR TITLE
add rollup-plugin-strip-prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Plugins which affect the final output of a bundle.
 - [shift-header](https://github.com/jacksonrayhamilton/rollup-plugin-shift-header) - Move comment headers to the top of a bundle.
 - [sri](https://github.com/JonasKruckenberg/rollup-plugin-sri) - Add subresource integrity attributes for your bundle.
 - [static-site](https://gitlab.com/thekelvinliu/rollup-plugin-static-site) - Generate HTML for a bundle.
+- [strip-prop-types](https://github.com/m00nbyte/rollup-plugin-strip-prop-types) - Removes propTypes, defaultProps, and prop-types imports, with TypeScript support and custom import paths.
 - [terser](https://github.com/TrySound/rollup-plugin-terser) - Minify a bundle using Terser.
 - [uglify](https://github.com/TrySound/rollup-plugin-uglify) - Minify a bundle with UglifyJS.
 - [version-injector](https://github.com/djhouseknecht/rollup-plugin-version-injector) - Inject your package’s version number into static build files.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/m00nbyte/rollup-plugin-strip-prop-types

### Please Describe Your Addition

Removes propTypes, defaultProps, and prop-types imports, with TypeScript support and custom import paths.