### PR TITLE
Add flatten-dir plugin for importing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Plugins which allow importing other types of files as modules.
 - [vinyl](https://github.com/operandom/rollup-plugin-vinyl) - Import from [Vinyl](https://github.com/gulpjs/vinyl) files
 - [smart-asset](https://github.com/sormy/rollup-plugin-smart-asset) - Import any assets as url using rebase, copy or inline mode. Similar to `url` but has more hashing options and works well together with babel using transform hook.
 - [toml](https://github.com/YanceyOfficial/rollup-plugin-toml) - Convert .toml files to ES6 modules.
-- [flatten-dir](https://github.com/promplate/rollup-plugin-flatten-dir) - Import directories as a path-content object, useful for working with @pyodide and @stackblitz.
+- [flatten-dir](https://github.com/promplate/rollup-plugin-flatten-dir) - Import directories as a path-content object, especially useful for working with [pyodide](https://github.com/pyodide) and [stackblitz](https://github.com/stackblitz).
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Plugins which allow importing other types of files as modules.
 - [vinyl](https://github.com/operandom/rollup-plugin-vinyl) - Import from [Vinyl](https://github.com/gulpjs/vinyl) files
 - [smart-asset](https://github.com/sormy/rollup-plugin-smart-asset) - Import any assets as url using rebase, copy or inline mode. Similar to `url` but has more hashing options and works well together with babel using transform hook.
 - [toml](https://github.com/YanceyOfficial/rollup-plugin-toml) - Convert .toml files to ES6 modules.
+- [flatten-dir](https://github.com/promplate/rollup-plugin-flatten-dir) - Import directories as a path-content object, useful for working with @pyodide and @stackblitz.
 
 ### Output
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/promplate/rollup-plugin-flatten-dir

### Please Describe Your Addition

This package can import a directory into module whose default export is a `Record<string, string>`. The keys are file pathes and values are file contents.

[This format is used in StackBlitz's SDK for submitting files onto its workspace](https://developer.stackblitz.com/platform/api/javascript-sdk-options#projectfiles). With this rollup plugin, people can easily embed StackBlitz demos in their rollup/vite websites.

Besides, it is easy to load files into Pyodide's filesystem with this plugin, which is also good to make use of vite's HMR feature to work with Pyodide.

Here is a simple demo for its functionality:

[![](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/edit/rollup-plugin-flatten-dir-demo?file=vite.config.ts)