### PR TITLE
remove rollup-plugin-styles from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Plugins for working with CSS.
 - [postcss](https://github.com/egoist/rollup-plugin-postcss) - Seamless integration with PostCSS.
 - [sass](https://github.com/differui/rollup-plugin-sass#readme) - SASS integration for a bundle.
 - [scss](https://github.com/thgh/rollup-plugin-scss) - Compile SASS and CSS.
-- [styles](https://github.com/Anidetrix/rollup-plugin-styles) - Universal plugin for styles: PostCSS, Sass, Less, Stylus and more.
 - [stylus-css-modules](https://github.com/mtojo/rollup-plugin-stylus-css-modules) – Compile Stylus and inject CSS modules
 - [sass-variables](https://github.com/gmfun/rollup-plugin-sass-variables) - Import SASS variables as Objects.
 


### PR DESCRIPTION
Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your ~Addition~ Removal

https://github.com/Anidetrix/rollup-plugin-styles

### Please Describe Your ~Addition~ Removal

This package is unmaintained and only supports rollup 2.x. There were attempts to contribute new version support, but no response: https://github.com/Anidetrix/rollup-plugin-styles/pull/225

At this point it would be better not to confuse people by suggesting an outdated package

