### PR TITLE
docs: adds rollup-plugin-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Plugins which affect the final output of a bundle.
 
 Plugins for working with template languages.
 
+- [content](https://github.com/stalniy/rollup-plugin-content) - Static content generation from different file formats (e.g., yaml, json, front-matter)
 - [twig](https://github.com/fm-ph/rollup-plugin-twig) - Import pre-compiled Twig.js templates.
 - [dustjs](https://github.com/chrisdothtml/rollup-plugin-dustjs) - Import Dust.js templates.
 - [eft](https://github.com/ClassicOldSong/rollup-plugin-eft) - Compile ef.js templates.
@@ -226,7 +227,6 @@ Plugins for working with template languages.
 - [pug](https://github.com/aMarCruz/rollup-plugin-pug) - Compile Pug Templates as es6 modules.
 - [pug-html](https://github.com/tycho01/rollup-plugin-pug-html) - Import Pug Templates as HTML strings during a build.
 - [reshape](https://github.com/Vanilla-IceCream/rollup-plugin-reshape) - Compile Reshape Templates.
-- [content](https://github.com/stalniy/rollup-plugin-content) - Static content generation from different file formats (e.g., yaml, json, front-matter)
 
 ### Text Replacement
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Plugins for working with template languages.
 - [pug](https://github.com/aMarCruz/rollup-plugin-pug) - Compile Pug Templates as es6 modules.
 - [pug-html](https://github.com/tycho01/rollup-plugin-pug-html) - Import Pug Templates as HTML strings during a build.
 - [reshape](https://github.com/Vanilla-IceCream/rollup-plugin-reshape) - Compile Reshape Templates.
+- [content](https://github.com/stalniy/rollup-plugin-content) - Static content generation from different file formats (e.g., yaml, json, front-matter)
 
 ### Text Replacement
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have completed or
  verified the step. Please do not skip this template or your issue will be
  closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!--
  !!!! ATTENTION !!!!
  
  DO NOT CHECK THE BOXES IF YOU HAVE NOT READ THE GUIDELINES

  Any Pull Request which does not adhere to the guidelines
  -- WILL BE CLOSED WITHOUT COMMENT --
  Please, we beg you, take the time to read the Contributing Guidelines. 
  
  !!!! ATTENTION !!!!

-->
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/rollup/awesome/blob/master/.github/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Provide a Link A Repository for Your Addition

https://github.com/stalniy/rollup-plugin-content

### Please Describe Your Addition

Static content & summary generator for Rollup, with i18n support, custom parsers, and plugin hooks (e.g., for search indexing with MiniSearch). Used in production by the [CASL docs](https://casl.js.org/v6/en/) for many years.


